### PR TITLE
Added fix for array mangling.  Added tests.  Updated version to 2.0.0.

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -145,17 +145,33 @@ function createEnvVariables(configPath){
 }
 
 function deepParse(obj) {
+
+    // Arrays need to be handled a little differently than other objects to avoid converting them to key/value pairs
+    if(Array.isArray(obj)) {
+        return obj.map((item) => {
+            if (typeof item === 'object') {
+                return deepParse(item);
+            } else {
+                return interpolate(item)
+            }
+        })
+    }
+
     return _.mapValues(obj, function(item){
         if(typeof item === 'object') {
             return deepParse(item);
         } else {
-            var fieldName = item.toString().split(":");
-            if (fieldName[0] === "$env") {
-                item = process.env[fieldName[1]];// split the field[item]
-            }
-            return item;
+            return interpolate(item)
         }
     });
+}
+
+function interpolate(string) {
+    var fieldName = string.toString().split(":");
+    if (fieldName[0] === "$env") {
+        return process.env[fieldName[1]];// split the field[item]
+    }
+    return string;
 }
 
 // Object.freeze() is not recursive. This allows for that.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelcorp/config-builder",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Environment Configuration Builder",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,8 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "chai": "^4.3.6"
+    "chai": "^4.3.6",
+    "mocha": "^10.3.0"
   },
   "bugs": {
     "url": "https://github.com/intel/config-builder/issues"

--- a/test/config/envs/E_Nested/config.json
+++ b/test/config/envs/E_Nested/config.json
@@ -1,0 +1,14 @@
+{
+	"nested": [
+		{ "foo": "bar" },
+		{
+			"baz": [ "foo", "bar" ]
+		},
+		[
+			[1,2,3]
+		]
+	],
+	"nestedAndInterpolated": [
+		["$env:HOME"]
+	]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,17 @@ describe('ConfigBuilder Test Suite', function () {
         expect(config).to.have.property('settingC');
     });
 
+    it( 'should properly construct nested config fields', function () {
+        var cb = new ConfigBuilder({ path: resolve(__dirname, 'config') });
+        var config = cb.build("E_Nested");
+        expect(config).to.have.property('nested');
+        expect(config.nested).to.deep.equal([
+            { "foo": "bar" },
+            { "baz": [ "foo", "bar" ] },
+            [[1,2,3]]
+        ]);
+    });
+
     it('should override top-level config settings for each environment', function () {
         var cb = new ConfigBuilder({ path: resolve(__dirname, 'config') });
 
@@ -78,6 +89,12 @@ describe('ConfigBuilder Test Suite', function () {
         var config = cb.build("E1");
         expect(config.otherConfig.nest.settingOtherNestedEnv).to.equal(process.env.HOME);
     });
+
+    it('should do variable replacement in arrays', () => {
+        var cb = new ConfigBuilder({ path: resolve(__dirname, 'config') });
+        var config = cb.build("E_Nested");
+        expect(config.nestedAndInterpolated[0][0]).to.equal(process.env.HOME);
+    })
 
     it('should read a data file', function(){
         var cb = new ConfigBuilder({ path: resolve(__dirname, 'config') });


### PR DESCRIPTION
Fixes array handling in config files.  Prior code would convert arrays into objects with key/value pairs that are the array indices/values.  New code leaves arrays as arrays while retaining env interpolation..